### PR TITLE
Disable retry for 4xx HTTP responses

### DIFF
--- a/api/js/cli/rpc.js
+++ b/api/js/cli/rpc.js
@@ -60,6 +60,7 @@ var mitro = mitro || {};
         complete: function (response) {
           try {
             var rval = JSON.parse(response.text);
+            rval.status = response.status;
             if(response.status === 200){
               onSuccess(rval);
             } else {


### PR DESCRIPTION
Passopolis currently sends 2 requests to the app backend in some scenarios, including when a user tries to log-in with either an incorrect password or from an unverified device.
This is because the retry logic uses the backup server if an HTTP request results in an error. The intent of the retry logic was to not retry in case of a 4xx response, see api/js/cli/mitro_fe.js:wrapWithFailover :

    `cannotUseBackup = cannotUseBackup || (400 <= e.status && e.status < 500);`

However the browser version of the api/js/cli/rpc.js:PostToMitro function only passes the content of the HTTP response to the onError callback.

This change is to fix the browser version of PostToMitro to pass the HTTP response status code to the retry logic which fixes the issue mentioned earlier.