### PR TITLE
Use nix to manage npm dependencies when building

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -3,7 +3,7 @@ with nixpkgs;
 let
   keyzcar_src = fetchzip {
         url = https://github.com/mitro-co/keyczarjs/archive/master.zip;
-        sha256 = "0hcxiqpyvs504qd0ars658c1v4hxj87dg48xij28rvyixk634bvi";
+        sha256 = "17kkdmfhkasgw9l7081y0qm4bn9sf8gipx9dm9zpfyyjsi8j8n7c";
       };
   forge_src = fetchzip {
       url = https://github.com/digitalbazaar/forge/archive/0.3.0.zip;
@@ -79,18 +79,28 @@ let
     cp -r . $out/
     '';
   };
+
+  node_packages = import "${nixpkgs.path}/pkgs/top-level/node-packages.nix" {
+    pkgs = nixpkgs;
+    inherit (nixpkgs) stdenv nodejs fetchurl fetchgit;
+    neededNatives = [ nixpkgs.python ] ++ nixpkgs.lib.optional nixpkgs.stdenv.isLinux nixpkgs.utillinux;
+    self = node_packages;
+    generated = ../package.nix;
+  };
 in
 rec {
   chrome-extension = callPackage ./chrome-extension.nix {
     inherit forge_src;
     inherit keyzcar_src;
     inherit chrome-config;
+    inherit node_packages;
   };
 
   firefox-44-extension = callPackage ./firefox-44-extension.nix {
     inherit forge_src;
     inherit keyzcar_src;
     inherit firefox-44-config;
+    inherit node_packages;
     manifest = firefox-44-manifest;
   };
 

--- a/nix/chrome-extension.nix
+++ b/nix/chrome-extension.nix
@@ -1,4 +1,4 @@
-{ stdenv, closurecompiler, unzip, nodejs, python, lessc, zip, forge_src, keyzcar_src, chrome-config }:
+{ stdenv, closurecompiler, unzip, nodejs, python, lessc, zip, forge_src, keyzcar_src, chrome-config, node_packages }:
 stdenv.mkDerivation {
     name = "passopolis-chrome-extension";
     buildInputs = [
@@ -8,6 +8,8 @@ stdenv.mkDerivation {
       python
       lessc
       zip
+      node_packages.hogan
+      node_packages."hogan.js"
     ];
     srcs = ../../extensions;
 
@@ -49,11 +51,11 @@ stdenv.mkDerivation {
 
     mkdir -p ext/html/
     for t in $(find frontend/templates/*mustache); do
-        NODE_PATH=../node_modules/hogan/node_modules/ node ./mustache_renderer.js $t ext/html/$(basename $t .mustache).html
+        node ./mustache_renderer.js $t ext/html/$(basename $t .mustache).html
     done
 
     for t in $(find frontend/partials/*mustache); do
-        ../node_modules/.bin/hulk $t > ext/js/$(basename $t .mustache).js
+      hulk $t > ext/js/$(basename $t .mustache).js
     done
 
     # Remove tests

--- a/nix/firefox-44-extension.nix
+++ b/nix/firefox-44-extension.nix
@@ -1,4 +1,4 @@
-{ stdenv, closurecompiler, p7zip, unzip, nodejs, python, lessc, zip, forge_src, keyzcar_src, firefox-44-config, manifest }:
+{ stdenv, closurecompiler, p7zip, unzip, nodejs, python, lessc, zip, forge_src, keyzcar_src, firefox-44-config, manifest, node_packages }:
 stdenv.mkDerivation {
     name = "passopolis-firefox-44-extension";
     buildInputs = [
@@ -9,6 +9,8 @@ stdenv.mkDerivation {
       lessc
       zip
       p7zip
+      node_packages.hogan
+      node_packages."hogan.js"
     ];
     srcs = ../../extensions;
 
@@ -50,11 +52,11 @@ stdenv.mkDerivation {
 
     mkdir -p ext/html/
     for t in $(find frontend/templates/*mustache); do
-        NODE_PATH=../node_modules/hogan/node_modules/ node ./mustache_renderer.js $t ext/html/$(basename $t .mustache).html
+        node ./mustache_renderer.js $t ext/html/$(basename $t .mustache).html
     done
 
     for t in $(find frontend/partials/*mustache); do
-        ../node_modules/.bin/hulk $t > ext/js/$(basename $t .mustache).js
+        hulk $t > ext/js/$(basename $t .mustache).js
     done
 
     # Remove tests

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Mitro javascript cli dependencies only used for nix test suites",
   "author": "Passopolis <team@passopolis.com>",
   "dependencies": {
-    "hogan": "^1.0.2",
+    "hogan.js": "^3.0.2",
     "jasmine-node": "*",
     "webworker-threads": "*"
   }

--- a/package.nix
+++ b/package.nix
@@ -1,6 +1,44 @@
 { self, fetchurl, fetchgit ? null, lib }:
 
 {
+  by-spec."abbrev"."1" =
+    self.by-version."abbrev"."1.1.0";
+  by-version."abbrev"."1.1.0" = self.buildNodePackage {
+    name = "abbrev-1.1.0";
+    version = "1.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz";
+      name = "abbrev-1.1.0.tgz";
+      sha1 = "d0554c2256636e2f56e7c2e5ad183f859428d81f";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."bindings"."^1.2.1" =
+    self.by-version."bindings"."1.2.1";
+  by-version."bindings"."1.2.1" = self.buildNodePackage {
+    name = "bindings-1.2.1";
+    version = "1.2.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz";
+      name = "bindings-1.2.1.tgz";
+      sha1 = "14ad6113812d2d37d72e67b4cacb4bb726505f11";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
   by-spec."coffee-script"."~1.7.1" =
     self.by-version."coffee-script"."1.7.1";
   by-version."coffee-script"."1.7.1" = self.buildNodePackage {
@@ -8,7 +46,7 @@
     version = "1.7.1";
     bin = true;
     src = fetchurl {
-      url = "http://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz";
+      url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz";
       name = "coffee-script-1.7.1.tgz";
       sha1 = "62996a861780c75e6d5069d13822723b73404bfc";
     };
@@ -22,15 +60,15 @@
     cpu = [ ];
   };
   by-spec."gaze"."~0.5.1" =
-    self.by-version."gaze"."0.5.1";
-  by-version."gaze"."0.5.1" = self.buildNodePackage {
-    name = "gaze-0.5.1";
-    version = "0.5.1";
+    self.by-version."gaze"."0.5.2";
+  by-version."gaze"."0.5.2" = self.buildNodePackage {
+    name = "gaze-0.5.2";
+    version = "0.5.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz";
-      name = "gaze-0.5.1.tgz";
-      sha1 = "22e731078ef3e49d1c4ab1115ac091192051824c";
+      url = "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz";
+      name = "gaze-0.5.2.tgz";
+      sha1 = "40b709537d24d1d45767db5a908689dfe69ac44f";
     };
     deps = {
       "globule-0.1.0" = self.by-version."globule"."0.1.0";
@@ -48,7 +86,7 @@
     version = "3.1.21";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/glob/-/glob-3.1.21.tgz";
+      url = "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz";
       name = "glob-3.1.21.tgz";
       sha1 = "d29e0a055dea5138f4d07ed40e8982e83c2066cd";
     };
@@ -70,7 +108,7 @@
     version = "0.1.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/globule/-/globule-0.1.0.tgz";
+      url = "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz";
       name = "globule-0.1.0.tgz";
       sha1 = "d9c8edde1da79d125a151b79533b978676346ae5";
     };
@@ -92,7 +130,7 @@
     version = "1.2.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz";
+      url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz";
       name = "graceful-fs-1.2.3.tgz";
       sha1 = "15a4806a57547cb2d2dbf27f42e89a8c3451b364";
     };
@@ -111,7 +149,7 @@
     version = "1.7.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/growl/-/growl-1.7.0.tgz";
+      url = "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz";
       name = "growl-1.7.0.tgz";
       sha1 = "de2d66136d002e112ba70f3f10c31cf7c350b2da";
     };
@@ -123,6 +161,51 @@
     os = [ ];
     cpu = [ ];
   };
+  by-spec."hogan"."^1.0.2" =
+    self.by-version."hogan"."1.0.2";
+  by-version."hogan"."1.0.2" = self.buildNodePackage {
+    name = "hogan-1.0.2";
+    version = "1.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/hogan/-/hogan-1.0.2.tgz";
+      name = "hogan-1.0.2.tgz";
+      sha1 = "d8d5e57fae0e7787b3e01e14256f9d588a23d1f0";
+    };
+    deps = {
+      "hogan.js-3.0.2" = self.by-version."hogan.js"."3.0.2";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "hogan" = self.by-version."hogan"."1.0.2";
+  by-spec."hogan.js"."*" =
+    self.by-version."hogan.js"."3.0.2";
+  by-version."hogan.js"."3.0.2" = self.buildNodePackage {
+    name = "hogan.js-3.0.2";
+    version = "3.0.2";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz";
+      name = "hogan.js-3.0.2.tgz";
+      sha1 = "4cd9e1abd4294146e7679e41d7898732b02c7bfd";
+    };
+    deps = {
+      "nopt-1.0.10" = self.by-version."nopt"."1.0.10";
+      "mkdirp-0.3.0" = self.by-version."mkdirp"."0.3.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."hogan.js"."^3.0.2" =
+    self.by-version."hogan.js"."3.0.2";
+  "hogan.js" = self.by-version."hogan.js"."3.0.2";
   by-spec."inherits"."1" =
     self.by-version."inherits"."1.0.2";
   by-version."inherits"."1.0.2" = self.buildNodePackage {
@@ -130,7 +213,7 @@
     version = "1.0.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz";
+      url = "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz";
       name = "inherits-1.0.2.tgz";
       sha1 = "ca4309dadee6b54cc0b8d247e8d7c7a0975bdc9b";
     };
@@ -149,7 +232,7 @@
     version = "0.2.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/jasmine-growl-reporter/-/jasmine-growl-reporter-0.2.1.tgz";
+      url = "https://registry.npmjs.org/jasmine-growl-reporter/-/jasmine-growl-reporter-0.2.1.tgz";
       name = "jasmine-growl-reporter-0.2.1.tgz";
       sha1 = "d5f0a37b92f6a83fd5c6482b809495c90a8b55fe";
     };
@@ -169,15 +252,15 @@
     version = "2.0.0";
     bin = true;
     src = fetchurl {
-      url = "http://registry.npmjs.org/jasmine-node/-/jasmine-node-2.0.0.tgz";
+      url = "https://registry.npmjs.org/jasmine-node/-/jasmine-node-2.0.0.tgz";
       name = "jasmine-node-2.0.0.tgz";
       sha1 = "81751a72325f5497490b14181a55087f1b0371ff";
     };
     deps = {
       "coffee-script-1.7.1" = self.by-version."coffee-script"."1.7.1";
-      "walkdir-0.0.10" = self.by-version."walkdir"."0.0.10";
+      "walkdir-0.0.11" = self.by-version."walkdir"."0.0.11";
       "underscore-1.6.0" = self.by-version."underscore"."1.6.0";
-      "gaze-0.5.1" = self.by-version."gaze"."0.5.1";
+      "gaze-0.5.2" = self.by-version."gaze"."0.5.2";
       "mkdirp-0.3.5" = self.by-version."mkdirp"."0.3.5";
       "minimist-0.0.8" = self.by-version."minimist"."0.0.8";
       "jasmine-growl-reporter-0.2.1" = self.by-version."jasmine-growl-reporter"."0.2.1";
@@ -196,7 +279,7 @@
     version = "1.0.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz";
+      url = "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz";
       name = "lodash-1.0.2.tgz";
       sha1 = "8f57560c83b59fc270bd3d561b690043430e2551";
     };
@@ -209,15 +292,15 @@
     cpu = [ ];
   };
   by-spec."lru-cache"."2" =
-    self.by-version."lru-cache"."2.7.0";
-  by-version."lru-cache"."2.7.0" = self.buildNodePackage {
-    name = "lru-cache-2.7.0";
-    version = "2.7.0";
+    self.by-version."lru-cache"."2.7.3";
+  by-version."lru-cache"."2.7.3" = self.buildNodePackage {
+    name = "lru-cache-2.7.3";
+    version = "2.7.3";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz";
-      name = "lru-cache-2.7.0.tgz";
-      sha1 = "aaa376a4cd970f9cebf5ec1909566ec034f07ee6";
+      url = "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz";
+      name = "lru-cache-2.7.3.tgz";
+      sha1 = "6d4524e8b955f95d4f5b58851ce21dd72fb4e952";
     };
     deps = {
     };
@@ -234,12 +317,12 @@
     version = "0.2.14";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz";
+      url = "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz";
       name = "minimatch-0.2.14.tgz";
       sha1 = "c74e780574f63c6f9a090e90efbe6ef53a6a756a";
     };
     deps = {
-      "lru-cache-2.7.0" = self.by-version."lru-cache"."2.7.0";
+      "lru-cache-2.7.3" = self.by-version."lru-cache"."2.7.3";
       "sigmund-1.0.1" = self.by-version."sigmund"."1.0.1";
     };
     optionalDependencies = {
@@ -255,9 +338,28 @@
     version = "0.0.8";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz";
+      url = "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz";
       name = "minimist-0.0.8.tgz";
       sha1 = "857fcabfc3397d2625b8228262e86aa7a011b05d";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."mkdirp"."0.3.0" =
+    self.by-version."mkdirp"."0.3.0";
+  by-version."mkdirp"."0.3.0" = self.buildNodePackage {
+    name = "mkdirp-0.3.0";
+    version = "0.3.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz";
+      name = "mkdirp-0.3.0.tgz";
+      sha1 = "1bbf5ab1ba827af23575143490426455f481fe1e";
     };
     deps = {
     };
@@ -274,7 +376,7 @@
     version = "0.3.5";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz";
+      url = "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz";
       name = "mkdirp-0.3.5.tgz";
       sha1 = "de3e5f8961c88c787ee1368df849ac4413eca8d7";
     };
@@ -286,18 +388,38 @@
     os = [ ];
     cpu = [ ];
   };
-  by-spec."nan"."^2.0.9" =
-    self.by-version."nan"."2.0.9";
-  by-version."nan"."2.0.9" = self.buildNodePackage {
-    name = "nan-2.0.9";
-    version = "2.0.9";
+  by-spec."nan"."^2.4.0" =
+    self.by-version."nan"."2.6.2";
+  by-version."nan"."2.6.2" = self.buildNodePackage {
+    name = "nan-2.6.2";
+    version = "2.6.2";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/nan/-/nan-2.0.9.tgz";
-      name = "nan-2.0.9.tgz";
-      sha1 = "d02a770f46778842cceb94e17cab31ffc7234a05";
+      url = "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz";
+      name = "nan-2.6.2.tgz";
+      sha1 = "e4ff34e6c95fdfb5aecc08de6596f43605a7db45";
     };
     deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."nopt"."1.0.10" =
+    self.by-version."nopt"."1.0.10";
+  by-version."nopt"."1.0.10" = self.buildNodePackage {
+    name = "nopt-1.0.10";
+    version = "1.0.10";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz";
+      name = "nopt-1.0.10.tgz";
+      sha1 = "6ddd21bd2a31417b92727dd585f8a6f37608ebee";
+    };
+    deps = {
+      "abbrev-1.1.0" = self.by-version."abbrev"."1.1.0";
     };
     optionalDependencies = {
     };
@@ -312,7 +434,7 @@
     version = "1.0.1";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz";
+      url = "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz";
       name = "sigmund-1.0.1.tgz";
       sha1 = "3ff21f198cad2175f9f3b781853fd94d0d19b590";
     };
@@ -331,7 +453,7 @@
     version = "1.6.0";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz";
+      url = "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz";
       name = "underscore-1.6.0.tgz";
       sha1 = "8b38b10cacdef63337b8b24e4ff86d45aea529a8";
     };
@@ -344,15 +466,15 @@
     cpu = [ ];
   };
   by-spec."walkdir"."~0.0.7" =
-    self.by-version."walkdir"."0.0.10";
-  by-version."walkdir"."0.0.10" = self.buildNodePackage {
-    name = "walkdir-0.0.10";
-    version = "0.0.10";
+    self.by-version."walkdir"."0.0.11";
+  by-version."walkdir"."0.0.11" = self.buildNodePackage {
+    name = "walkdir-0.0.11";
+    version = "0.0.11";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/walkdir/-/walkdir-0.0.10.tgz";
-      name = "walkdir-0.0.10.tgz";
-      sha1 = "36037cab663b5e1c0166007b5f7b918b3279a54f";
+      url = "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz";
+      name = "walkdir-0.0.11.tgz";
+      sha1 = "a16d025eb931bd03b52f308caed0f40fcebe9532";
     };
     deps = {
     };
@@ -363,18 +485,19 @@
     cpu = [ ];
   };
   by-spec."webworker-threads"."*" =
-    self.by-version."webworker-threads"."0.5.7";
-  by-version."webworker-threads"."0.5.7" = self.buildNodePackage {
-    name = "webworker-threads-0.5.7";
-    version = "0.5.7";
+    self.by-version."webworker-threads"."0.7.11";
+  by-version."webworker-threads"."0.7.11" = self.buildNodePackage {
+    name = "webworker-threads-0.7.11";
+    version = "0.7.11";
     bin = false;
     src = fetchurl {
-      url = "http://registry.npmjs.org/webworker-threads/-/webworker-threads-0.5.7.tgz";
-      name = "webworker-threads-0.5.7.tgz";
-      sha1 = "74c26e923b4bf25bf620533877d8548d6b221877";
+      url = "https://registry.npmjs.org/webworker-threads/-/webworker-threads-0.7.11.tgz";
+      name = "webworker-threads-0.7.11.tgz";
+      sha1 = "9d54dfaa8d5ea3308833084680636b584a8aacaa";
     };
     deps = {
-      "nan-2.0.9" = self.by-version."nan"."2.0.9";
+      "bindings-1.2.1" = self.by-version."bindings"."1.2.1";
+      "nan-2.6.2" = self.by-version."nan"."2.6.2";
     };
     optionalDependencies = {
     };
@@ -382,5 +505,5 @@
     os = [ ];
     cpu = [ ];
   };
-  "webworker-threads" = self.by-version."webworker-threads"."0.5.7";
+  "webworker-threads" = self.by-version."webworker-threads"."0.7.11";
 }


### PR DESCRIPTION
This should avoid issues like #40 in the future.

Please note the keyczar update.